### PR TITLE
Add pytest suite and tests CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      QT_QPA_PLATFORM: offscreen
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Qt system libraries
+        run: sudo apt-get update && sudo apt-get install -y libegl1
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ python3 main.py
 
 Check the folder path in the top bar and press **Analyze**.
 
+## Tests
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
+The suite runs offscreen (no display needed) on synthetic images and a temp
+database: crop math, data queries, person edits, clustering/recluster logic,
+the responsive grid and the lightbox interactions. CI runs it on every push
+and pull request via the [tests workflow](.github/workflows/tests.yml).
+
 ## Build executables
 
 Executables are built with PyInstaller — locally:
@@ -95,6 +107,7 @@ Windows, Linux and macOS runners and attaches them to a GitHub release.
 | `database.py`                | SQLite schema and connection helpers           |
 | `paths.py`                   | Path resolution (source vs frozen bundle)      |
 | `scripts/download_models.py` | Downloads YuNet and SFace ONNX models          |
+| `tests/`                     | Pytest suite (offscreen, synthetic data)       |
 | `myphotos.spec`              | PyInstaller build spec                         |
 
 ## Storage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,125 @@
+"""Shared fixtures: offscreen Qt, a temp database and synthetic photos."""
+
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from PIL import Image  # noqa: E402
+
+import database  # noqa: E402
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    """Fresh SQLite database in a temp dir; database.DB_PATH is patched."""
+    monkeypatch.setattr(database, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+    return database
+
+
+def _embedding(seed, dim=8):
+    """Deterministic unit vector; nearby seeds in the same hundred are close."""
+    base = np.zeros(dim, dtype=np.float32)
+    base[seed // 100] = 1.0
+    rng = np.random.default_rng(seed)
+    vec = base + rng.normal(0, 0.01, dim).astype(np.float32)
+    return vec / np.linalg.norm(vec)
+
+
+@pytest.fixture()
+def seeded(db, tmp_path):
+    """Three photos (two persons: Alice on 1&2, Bob on 2&3) with real files.
+
+    Returns a dict with photo/person ids for assertions.
+    """
+    conn = db.get_db()
+    sizes = [(400, 300), (300, 400), (600, 600)]
+    photo_ids = []
+    for i, (w, h) in enumerate(sizes, start=1):
+        path = tmp_path / f"img{i}.jpg"
+        Image.new("RGB", (w, h), ((i * 60) % 255, 120, 160)).save(path)
+        cur = conn.execute(
+            "INSERT INTO photos (path, filename, width, height, mtime)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (str(path), path.name, w, h, os.path.getmtime(path)),
+        )
+        photo_ids.append(cur.lastrowid)
+
+    alice = conn.execute("INSERT INTO persons (name) VALUES ('Alice')").lastrowid
+    bob = conn.execute("INSERT INTO persons (name) VALUES ('Bob')").lastrowid
+
+    faces = [
+        (photo_ids[0], alice, 10, 10, 50, 60, 0.9, 0),
+        (photo_ids[1], alice, 100, 120, 40, 40, 0.95, 1),
+        (photo_ids[1], bob, 200, 220, 60, 50, 0.8, 100),
+        (photo_ids[2], bob, 300, 300, 80, 80, 0.99, 101),
+    ]
+    face_ids = []
+    for photo_id, person_id, x, y, w, h, score, emb_seed in faces:
+        cur = conn.execute(
+            "INSERT INTO faces (photo_id, person_id, x, y, w, h, score, embedding)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (photo_id, person_id, x, y, w, h, score, _embedding(emb_seed).tobytes()),
+        )
+        face_ids.append(cur.lastrowid)
+    conn.commit()
+    conn.close()
+
+    return {
+        "photo_ids": photo_ids,
+        "alice": alice,
+        "bob": bob,
+        "face_ids": face_ids,
+    }
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    app.setOrganizationName("myPhotosTest")
+    app.setApplicationName("myPhotosTest")
+    return app
+
+
+@pytest.fixture()
+def isolated_settings(qapp, tmp_path):
+    """Redirect QSettings to a temp ini file and wipe it."""
+    from PySide6.QtCore import QSettings
+
+    QSettings.setDefaultFormat(QSettings.IniFormat)
+    QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, str(tmp_path))
+    QSettings().clear()
+    return QSettings
+
+
+def wait_idle(qapp, window, timeout=10.0):
+    """Process events until the image loader has no pending work."""
+    import time
+
+    deadline = time.time() + timeout
+    while not window.loader.is_idle() and time.time() < deadline:
+        qapp.processEvents()
+        time.sleep(0.02)
+    for _ in range(20):
+        qapp.processEvents()
+
+
+@pytest.fixture()
+def window(qapp, seeded, isolated_settings):
+    from gui.window import MainWindow
+
+    win = MainWindow()
+    win.resize(1280, 860)
+    win.show()
+    wait_idle(qapp, win)
+    yield win
+    win.lightbox.close()
+    win.close()
+    win.deleteLater()
+    qapp.processEvents()

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,113 @@
+"""Tests for analyzer helpers: file scan, clustering and recluster mapping."""
+
+import numpy as np
+
+import analyzer
+from analyzer import Analyzer, _average_linkage, _normalize, scan_image_files
+
+
+def _unit(dim, axis, noise_seed=None):
+    vec = np.zeros(dim, dtype=np.float32)
+    vec[axis] = 1.0
+    if noise_seed is not None:
+        rng = np.random.default_rng(noise_seed)
+        vec = vec + rng.normal(0, 0.01, dim).astype(np.float32)
+    return vec / np.linalg.norm(vec)
+
+
+class TestScan:
+    def test_recursive_sorted_and_filtered(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        for name in ["b.JPG", "a.png", "sub/c.webp", "notes.txt", "d.tiff"]:
+            (tmp_path / name).write_bytes(b"x")
+        files = scan_image_files(str(tmp_path))
+        names = [f.replace(str(tmp_path) + "/", "") for f in files]
+        assert names == sorted(["b.JPG", "a.png", "sub/c.webp", "d.tiff"])
+
+
+class TestNormalize:
+    def test_unit_norm(self):
+        vec = _normalize(np.array([3.0, 4.0], dtype=np.float32))
+        assert abs(np.linalg.norm(vec) - 1.0) < 1e-6
+
+    def test_zero_vector_unchanged(self):
+        vec = _normalize(np.zeros(4, dtype=np.float32))
+        assert not np.any(vec)
+
+
+class TestAverageLinkage:
+    def test_two_tight_groups(self):
+        embeddings = np.stack(
+            [_unit(8, 0, s) for s in range(3)] + [_unit(8, 1, s) for s in range(3)]
+        )
+        clusters = _average_linkage(embeddings, threshold=0.3)
+        assert sorted(sorted(c) for c in clusters) == [[0, 1, 2], [3, 4, 5]]
+
+    def test_orthogonal_vectors_stay_separate(self):
+        embeddings = np.stack([_unit(4, i) for i in range(4)])
+        clusters = _average_linkage(embeddings, threshold=0.3)
+        assert len(clusters) == 4
+
+
+def _seed_faces(db, groups):
+    """Insert one photo and faces: groups is a list of (axis, person_id)."""
+    conn = db.get_db()
+    photo_id = conn.execute(
+        "INSERT INTO photos (path, filename, width, height, mtime)"
+        " VALUES ('/x.jpg', 'x.jpg', 100, 100, 0)"
+    ).lastrowid
+    max_person = max(pid for _, pid in groups)
+    for pid in range(1, max_person + 1):
+        conn.execute("INSERT INTO persons (id, name) VALUES (?, ?)", (pid, f"P{pid}"))
+    face_ids = []
+    for i, (axis, person_id) in enumerate(groups):
+        emb = _unit(8, axis, noise_seed=i)
+        face_ids.append(
+            conn.execute(
+                "INSERT INTO faces (photo_id, person_id, x, y, w, h, score, embedding)"
+                " VALUES (?, ?, 0, 0, 30, 30, 0.9, ?)",
+                (photo_id, person_id, emb.tobytes()),
+            ).lastrowid
+        )
+    conn.commit()
+    return conn, face_ids
+
+
+class TestRecluster:
+    def test_manual_merge_of_two_clusters_is_preserved(self, db):
+        # Two distinct embedding groups, all manually assigned to person 1.
+        conn, face_ids = _seed_faces(db, [(0, 1), (0, 1), (1, 1), (1, 1)])
+        Analyzer()._recluster(conn, confirmed_ids=set(face_ids))
+        persons = conn.execute(
+            "SELECT DISTINCT person_id FROM faces"
+        ).fetchall()
+        assert [r["person_id"] for r in persons] == [1]
+        conn.close()
+
+    def test_greedy_overmerge_is_split_for_fresh_faces(self, db):
+        # Group A confirmed as person 1; group B greedily got person 1 this run.
+        conn, face_ids = _seed_faces(db, [(0, 1), (0, 1), (1, 1), (1, 1)])
+        Analyzer()._recluster(conn, confirmed_ids=set(face_ids[:2]))
+        rows = conn.execute("SELECT id, person_id FROM faces ORDER BY id").fetchall()
+        by_face = {r["id"]: r["person_id"] for r in rows}
+        assert by_face[face_ids[0]] == by_face[face_ids[1]] == 1
+        assert by_face[face_ids[2]] == by_face[face_ids[3]] != 1
+        conn.close()
+
+    def test_orphaned_persons_are_deleted(self, db):
+        conn, face_ids = _seed_faces(db, [(0, 1), (0, 1), (0, 2)])
+        # All three faces form one cluster; person 1 wins the vote 2:1 and
+        # person 2 loses its only face.
+        Analyzer()._recluster(conn, confirmed_ids=set(face_ids))
+        names = [r["name"] for r in conn.execute("SELECT name FROM persons").fetchall()]
+        assert names == ["P1"]
+        conn.close()
+
+    def test_small_and_large_sets_are_skipped(self, db, monkeypatch):
+        conn, face_ids = _seed_faces(db, [(0, 1)])
+        Analyzer()._recluster(conn, confirmed_ids=set())  # single face: no-op
+        assert conn.execute("SELECT person_id FROM faces").fetchone()[0] == 1
+        monkeypatch.setattr(analyzer, "MAX_RECLUSTER_FACES", 0)
+        Analyzer()._recluster(conn, confirmed_ids=set())  # over the cap: no-op
+        assert conn.execute("SELECT person_id FROM faces").fetchone()[0] == 1
+        conn.close()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,94 @@
+"""Tests for gui.data: crop math and the read/write queries."""
+
+from gui import data
+
+
+class TestComputeCrop:
+    def test_wide_image_portrait_crop_spans_height(self):
+        crop = data.compute_crop(400, 300, [], 3 / 4)
+        assert crop["h"] == 300
+        assert crop["w"] == round(300 * 3 / 4)
+        assert abs(crop["x"] - (400 - crop["w"]) / 2) <= 1
+
+    def test_tall_image_landscape_crop_spans_width(self):
+        crop = data.compute_crop(300, 400, [], 4 / 3)
+        assert crop["w"] == 300
+        assert crop["h"] == round(300 / (4 / 3))
+
+    def test_no_faces_centers_on_middle(self):
+        crop = data.compute_crop(600, 600, [], 3 / 4)
+        assert crop["x"] + crop["w"] / 2 == 300
+
+    def test_crop_centers_on_face_bbox(self):
+        faces = [{"x": 500, "y": 100, "w": 50, "h": 50}]
+        crop = data.compute_crop(1000, 400, faces, 3 / 4)
+        center = crop["x"] + crop["w"] / 2
+        assert abs(center - 525) <= 1
+
+    def test_crop_clamped_inside_image(self):
+        faces = [{"x": 980, "y": 380, "w": 20, "h": 20}]
+        crop = data.compute_crop(1000, 400, faces, 3 / 4)
+        assert crop["x"] >= 0 and crop["y"] >= 0
+        assert crop["x"] + crop["w"] <= 1000
+        assert crop["y"] + crop["h"] <= 400
+
+    def test_both_aspects_have_correct_ratio(self):
+        for key, aspect in data.THUMB_ASPECTS.items():
+            crop = data.compute_crop(1234, 987, [], aspect)
+            assert abs(crop["w"] / crop["h"] - aspect) < 0.01, key
+
+
+class TestQueries:
+    def test_list_photos_returns_all_with_faces(self, seeded):
+        photos = data.list_photos()
+        assert [p["filename"] for p in photos] == ["img1.jpg", "img2.jpg", "img3.jpg"]
+        by_name = {p["filename"]: p for p in photos}
+        assert len(by_name["img1.jpg"]["faces"]) == 1
+        assert len(by_name["img2.jpg"]["faces"]) == 2
+        assert all("crop" in p for p in photos)
+
+    def test_list_photos_filtered_by_person(self, seeded):
+        alice_photos = data.list_photos(person_id=seeded["alice"])
+        assert [p["filename"] for p in alice_photos] == ["img1.jpg", "img2.jpg"]
+        assert all(
+            any(f["person_id"] == seeded["alice"] for f in p["faces"])
+            for p in alice_photos
+        )
+
+    def test_list_persons_counts_and_order(self, seeded):
+        persons = data.list_persons()
+        assert {p["name"] for p in persons} == {"Alice", "Bob"}
+        for p in persons:
+            assert p["photo_count"] == 2
+            assert p["face_count"] == 2
+            assert p["portrait_face_id"] is not None
+
+    def test_portrait_face_is_highest_score(self, seeded):
+        persons = {p["name"]: p for p in data.list_persons()}
+        # Bob's img3 face has score 0.99 vs 0.8.
+        assert persons["Bob"]["portrait_face_id"] == seeded["face_ids"][3]
+
+    def test_rename_person(self, seeded):
+        data.rename_person(seeded["alice"], "Alicia")
+        assert {p["name"] for p in data.list_persons()} == {"Alicia", "Bob"}
+
+    def test_merge_moves_faces_and_deletes_source(self, seeded):
+        data.merge_person(seeded["alice"], seeded["bob"])
+        persons = data.list_persons()
+        assert len(persons) == 1
+        assert persons[0]["id"] == seeded["bob"]
+        assert persons[0]["face_count"] == 4
+        assert persons[0]["photo_count"] == 3
+
+    def test_delete_person_keeps_photos(self, seeded):
+        data.delete_person(seeded["bob"])
+        assert {p["name"] for p in data.list_persons()} == {"Alice"}
+        photos = data.list_photos()
+        assert len(photos) == 3  # photos stay
+        assert len([f for p in photos for f in p["faces"]]) == 2  # Bob's boxes gone
+
+    def test_face_portrait_source(self, seeded):
+        row = data.face_portrait_source(seeded["face_ids"][0])
+        assert row["x"] == 10 and row["w"] == 50
+        assert row["path"].endswith("img1.jpg")
+        assert data.face_portrait_source(99999) is None

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,184 @@
+"""Offscreen GUI tests: window state, responsive grid, lightbox interactions."""
+
+import pytest
+from PySide6.QtCore import QEvent, QPoint, QPointF, Qt
+from PySide6.QtGui import QKeyEvent, QMouseEvent, QWheelEvent
+
+from tests.conftest import wait_idle
+
+
+def wheel(widget, pos, steps):
+    widget.wheelEvent(
+        QWheelEvent(
+            pos, pos, QPoint(0, 0), QPoint(0, steps * 120),
+            Qt.NoButton, Qt.NoModifier, Qt.NoScrollPhase, False,
+        )
+    )
+
+
+def press(widget, pos):
+    widget.mousePressEvent(
+        QMouseEvent(QEvent.MouseButtonPress, pos, pos, Qt.LeftButton,
+                    Qt.LeftButton, Qt.NoModifier)
+    )
+
+
+def move(widget, pos):
+    widget.mouseMoveEvent(
+        QMouseEvent(QEvent.MouseMove, pos, pos, Qt.NoButton,
+                    Qt.LeftButton, Qt.NoModifier)
+    )
+
+
+def release(widget, pos):
+    widget.mouseReleaseEvent(
+        QMouseEvent(QEvent.MouseButtonRelease, pos, pos, Qt.LeftButton,
+                    Qt.NoButton, Qt.NoModifier)
+    )
+
+
+def click(widget, pos):
+    press(widget, pos)
+    release(widget, pos)
+
+
+class TestWindow:
+    def test_gallery_and_people_populated(self, window):
+        assert window.windowTitle() == "myPhotos"
+        assert len(window.gallery._model.photos()) == 3
+        assert len(window.people.persons()) == 2
+        assert window.stack.currentIndex() == 0  # gallery, not empty state
+        assert not window.filter_banner.isVisible()
+
+    def test_person_filter_toggles(self, qapp, window):
+        alice = window.people.persons()[0]
+        window._on_person_clicked(alice["id"])
+        wait_idle(qapp, window)
+        assert len(window.gallery._model.photos()) == 2
+        assert window.filter_banner.isVisible()
+        assert alice["name"] in window.filter_label.text()
+        window._on_person_clicked(alice["id"])  # same person: filter off
+        assert len(window.gallery._model.photos()) == 3
+        assert not window.filter_banner.isVisible()
+
+    def test_people_rebuild_does_not_duplicate_rows(self, qapp, window):
+        persons = window.people.persons()
+        window.people.rebuild(persons, persons[0]["id"])
+        window.people.rebuild(persons, None)
+        qapp.processEvents()
+        assert len(window.people._rows) == len(persons)
+
+    def test_aspect_toggle_persists_between_windows(self, qapp, window, seeded):
+        from gui.window import MainWindow
+
+        assert window.aspect_key == "34"  # vertical by default
+        window._toggle_aspect()
+        assert window.aspect_key == "43"
+        second = MainWindow()
+        try:
+            assert second.aspect_key == "43"
+        finally:
+            second.close()
+            second.deleteLater()
+            qapp.processEvents()
+
+    def test_boxes_toggle_updates_delegate(self, window):
+        assert window.gallery.delegate.show_boxes is True
+        window._toggle_boxes()
+        assert window.show_boxes is False
+        assert window.gallery.delegate.show_boxes is False
+
+    def test_empty_database_shows_empty_state(self, qapp, db, isolated_settings):
+        from gui.window import MainWindow
+
+        win = MainWindow()
+        win.show()
+        try:
+            assert win.stack.currentIndex() == 1
+            assert win.people.empty.isVisible() or not win.people.persons()
+        finally:
+            win.close()
+            win.deleteLater()
+            qapp.processEvents()
+
+
+class TestGrid:
+    @pytest.mark.parametrize("width", [1000, 1280, 1680])
+    def test_always_four_columns(self, qapp, window, width):
+        window.resize(width, 860)
+        qapp.processEvents()
+        view = window.gallery
+        cell = view.gridSize().width()
+        viewport = view.viewport().width()
+        assert viewport // cell == 4
+        assert viewport - 4 * cell < cell  # leftover smaller than a column
+
+
+class TestLightbox:
+    @pytest.fixture()
+    def lightbox(self, qapp, window):
+        window._open_lightbox(window.gallery._model.photos()[1])
+        qapp.processEvents()
+        return window.lightbox
+
+    def test_opens_on_requested_photo(self, lightbox):
+        assert lightbox.isVisible()
+        assert lightbox._index == 1
+        assert lightbox._pixmap is not None
+
+    def test_wheel_zooms_around_cursor_and_back(self, lightbox):
+        target = QPointF(lightbox.width() * 0.6, lightbox.height() * 0.4)
+        wheel(lightbox, target, 4)
+        assert abs(lightbox._zoom - 1.15 ** 4) < 1e-6
+        wheel(lightbox, target, -10)
+        assert lightbox._zoom == 1.0
+        assert lightbox._pan == QPointF(0, 0)  # pan clamps to center at fit
+
+    def test_drag_pans_when_overflowing(self, lightbox):
+        center = QPointF(lightbox.width() / 2, lightbox.height() / 2)
+        wheel(lightbox, center, 12)  # far beyond the window size
+        size = lightbox._fit_size() * lightbox._zoom
+        assert size.x() > lightbox.width() and size.y() > lightbox.height()
+        pan_before = QPointF(lightbox._pan)
+        press(lightbox, center)
+        move(lightbox, center + QPointF(-80, -40))
+        release(lightbox, center + QPointF(-80, -40))
+        moved = lightbox._pan - pan_before
+        assert abs(moved.x() + 80) < 2 and abs(moved.y() + 40) < 2
+        assert lightbox.isVisible()  # a drag never closes the overlay
+
+    def test_side_zones_navigate(self, lightbox):
+        click(lightbox, QPointF(30, lightbox.height() / 2))
+        assert lightbox._index == 0
+        click(lightbox, QPointF(lightbox.width() - 30, lightbox.height() / 2))
+        assert lightbox._index == 1
+
+    def test_arrow_keys_navigate_without_wrap(self, lightbox):
+        lightbox.keyPressEvent(QKeyEvent(QEvent.KeyPress, Qt.Key_Right, Qt.NoModifier))
+        assert lightbox._index == 2
+        lightbox.keyPressEvent(QKeyEvent(QEvent.KeyPress, Qt.Key_Right, Qt.NoModifier))
+        assert lightbox._index == 2  # last photo: no wrap
+        lightbox._load(0)
+        lightbox.keyPressEvent(QKeyEvent(QEvent.KeyPress, Qt.Key_Left, Qt.NoModifier))
+        assert lightbox._index == 0
+
+    def test_close_button_top_right(self, qapp, lightbox):
+        assert lightbox._close_btn.x() == lightbox.width() - 36 - 16
+        assert lightbox._close_btn.y() == 16
+        lightbox._close_btn.click()
+        qapp.processEvents()
+        assert not lightbox.isVisible()
+
+    def test_background_click_closes(self, qapp, lightbox):
+        corner = QPointF(lightbox.width() * 0.2, 20)
+        assert lightbox._zone_at(corner) is None
+        assert not lightbox._draw_rect().contains(corner)
+        click(lightbox, corner)
+        qapp.processEvents()
+        assert not lightbox.isVisible()
+
+    def test_navigation_resets_zoom(self, lightbox):
+        wheel(lightbox, QPointF(lightbox.width() / 2, lightbox.height() / 2), 5)
+        assert lightbox._zoom > 1
+        lightbox._load(2)
+        assert lightbox._zoom == 1.0


### PR DESCRIPTION
40 offscreen tests (no display, no models, synthetic images + temp DB): crop math, data queries, person edits, clustering/recluster logic, responsive grid, lightbox interactions. New `tests` workflow runs them on every push and PR.