### PR TITLE
Add structured logging and user-facing error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Windows, Linux and macOS runners and attaches them to a GitHub release.
 ## Storage
 
 - Running from source: `myphoto.db` next to the code.
-- Running a packaged executable: `~/.myphoto/myphoto.db`.
+- Running a packaged executable: `~/.myphoto/myphoto.db`, with a rotating
+  `~/.myphoto/myphotos.log` for debugging (windowed builds have no console).
 - View settings (preview aspect, face-box visibility) are stored with Qt
   `QSettings` under the `myPhotos` organization.

--- a/analyzer.py
+++ b/analyzer.py
@@ -1,5 +1,6 @@
 """Recursive photo scanning, face detection (YuNet) and face clustering (SFace)."""
 
+import logging
 import os
 import threading
 
@@ -8,6 +9,8 @@ import numpy as np
 
 from database import get_db
 from paths import resource_dir
+
+log = logging.getLogger(__name__)
 
 MODELS_DIR = os.path.join(resource_dir(), "models")
 DETECTOR_MODEL = os.path.join(MODELS_DIR, "face_detection_yunet_2023mar.onnx")
@@ -140,13 +143,14 @@ class Analyzer:
                 try:
                     self._process_photo(db, detector, recognizer, persons, path)
                 except Exception as exc:  # noqa: BLE001 - skip unreadable files
-                    print(f"[analyzer] skipping {path}: {exc}")
+                    log.warning("skipping %s: %s", path, exc)
 
             self._set(current="Clustering faces…")
             self._recluster(db, confirmed_ids)
             db.close()
             self._set(status="done", done=len(files), current="")
         except Exception as exc:  # noqa: BLE001
+            log.exception("analysis of %s failed", folder)
             self._set(status="error", error=str(exc))
 
     def _load_persons(self, db):

--- a/gui/lightbox.py
+++ b/gui/lightbox.py
@@ -5,6 +5,8 @@ photo, the side zones (or Left/Right arrow keys) switch photos, the ✕ button,
 Esc or a click on the empty background closes the overlay.
 """
 
+import logging
+
 from PySide6.QtCore import QPointF, QRectF, Qt
 from PySide6.QtGui import QColor, QPainter, QPixmap
 from PySide6.QtWidgets import QDialog, QToolButton
@@ -12,6 +14,8 @@ from PySide6.QtWidgets import QDialog, QToolButton
 from gui.facepaint import draw_face_boxes
 from gui.thumbs import _read_image
 from gui.theme import MUTED, TEXT
+
+log = logging.getLogger(__name__)
 
 CAPTION_H = 40
 MAX_ZOOM = 12.0
@@ -55,6 +59,8 @@ class Lightbox(QDialog):
     def _load(self, index):
         self._index = index
         image = _read_image(self._photos[index]["path"])
+        if image.isNull():
+            log.warning("could not read %s", self._photos[index]["path"])
         self._pixmap = None if image.isNull() else QPixmap.fromImage(image)
         self._zoom = 1.0
         self._pan = QPointF(0, 0)
@@ -200,6 +206,14 @@ class Lightbox(QDialog):
         painter.setRenderHint(QPainter.SmoothPixmapTransform)
         painter.fillRect(self.rect(), QColor(10, 11, 14, 235))
         if self._pixmap is None:
+            painter.setPen(QColor(MUTED))
+            font = painter.font()
+            font.setPixelSize(15)
+            painter.setFont(font)
+            path = self._photo["path"] if self._photos else ""
+            painter.drawText(
+                self.rect(), Qt.AlignCenter, f"Could not load image\n{path}"
+            )
             return
 
         dst = self._draw_rect()

--- a/gui/thumbs.py
+++ b/gui/thumbs.py
@@ -5,10 +5,14 @@ orientation the analyzer stored coordinates in) and hand QImages to the GUI
 thread through signals; pixmaps are created and cached there.
 """
 
+import logging
+
 from PySide6.QtCore import QObject, QRect, QRunnable, QSize, Qt, QThreadPool, Signal
 from PySide6.QtGui import QImage, QImageReader, QPixmap
 
 from gui.data import PORTRAIT_SIZE, THUMB_MAX, face_portrait_source
+
+log = logging.getLogger(__name__)
 
 
 def _read_image(path):
@@ -23,7 +27,10 @@ class _Job(QRunnable):
         self._fn = fn
 
     def run(self):
-        self._fn()
+        try:
+            self._fn()
+        except Exception:  # noqa: BLE001 - keep the thread pool alive
+            log.exception("image loader job failed")
 
 
 class ImageLoader(QObject):
@@ -57,7 +64,9 @@ class ImageLoader(QObject):
 
     def _load_thumb(self, key, path, crop):
         image = _read_image(path)
-        if not image.isNull():
+        if image.isNull():
+            log.warning("could not read thumbnail source %s", path)
+        else:
             image = image.copy(QRect(crop["x"], crop["y"], crop["w"], crop["h"]))
             image = image.scaled(
                 QSize(*THUMB_MAX[key[1]]), Qt.KeepAspectRatio, Qt.SmoothTransformation
@@ -84,8 +93,14 @@ class ImageLoader(QObject):
         return pixmap
 
     def _load_portrait(self, face_id):
-        row = face_portrait_source(face_id)
+        try:
+            row = face_portrait_source(face_id)
+        except Exception:  # noqa: BLE001 - a broken DB must not kill the worker
+            log.exception("loading portrait source for face %s failed", face_id)
+            row = None
         image = _read_image(row["path"]) if row else QImage()
+        if image.isNull() and row is not None:
+            log.warning("could not read portrait source %s", row["path"])
         if not image.isNull():
             # Square crop around the face with a 30% margin, clamped to the image.
             cx, cy = row["x"] + row["w"] / 2, row["y"] + row["h"] / 2

--- a/gui/window.py
+++ b/gui/window.py
@@ -1,5 +1,6 @@
 """Main window: top bar, analysis progress, gallery, people sidebar."""
 
+import logging
 import os
 
 from PySide6.QtCore import QSettings, Qt, QTimer
@@ -31,6 +32,8 @@ from gui.people import PeoplePanel
 from gui.theme import app_icon, aspect_icon, eye_icon
 from gui.thumbs import ImageLoader
 from paths import default_photos_dir
+
+log = logging.getLogger(__name__)
 
 POLL_INTERVAL_MS = 400
 SIDEBAR_W = 280
@@ -209,8 +212,17 @@ class MainWindow(QMainWindow):
 
     # ------------------------------------------------------------- refreshing
 
+    def _report_error(self, title, exc):
+        """Log a failed operation and tell the user instead of crashing."""
+        log.exception("%s failed", title)
+        QMessageBox.critical(self, title, f"{title} failed:\n{exc}")
+
     def refresh_persons(self):
-        persons = data.list_persons()
+        try:
+            persons = data.list_persons()
+        except Exception as exc:  # noqa: BLE001 - e.g. a corrupted database
+            self._report_error("Loading people", exc)
+            return
         if self.active_person_id is not None and not any(
             p["id"] == self.active_person_id for p in persons
         ):
@@ -219,7 +231,11 @@ class MainWindow(QMainWindow):
         self._update_filter_banner()
 
     def refresh_photos(self):
-        photos = data.list_photos(self.active_person_id, self.aspect_key)
+        try:
+            photos = data.list_photos(self.active_person_id, self.aspect_key)
+        except Exception as exc:  # noqa: BLE001 - e.g. a corrupted database
+            self._report_error("Loading photos", exc)
+            return
         self.gallery.set_photos(photos)
         self.stack.setCurrentIndex(0 if photos else 1)
 
@@ -253,7 +269,11 @@ class MainWindow(QMainWindow):
         )
         name = name.strip()
         if ok and name and name != person["name"]:
-            data.rename_person(person["id"], name)
+            try:
+                data.rename_person(person["id"], name)
+            except Exception as exc:  # noqa: BLE001
+                self._report_error("Rename person", exc)
+                return
             self.refresh_all()  # labels on photos use the person name
 
     def _merge_person(self, person):
@@ -273,7 +293,11 @@ class MainWindow(QMainWindow):
         )
         if answer != QMessageBox.Yes:
             return
-        data.merge_person(person["id"], target["id"])
+        try:
+            data.merge_person(person["id"], target["id"])
+        except Exception as exc:  # noqa: BLE001
+            self._report_error("Merge person", exc)
+            return
         if self.active_person_id == person["id"]:
             self.active_person_id = target["id"]
         self.refresh_all()
@@ -288,7 +312,11 @@ class MainWindow(QMainWindow):
         )
         if answer != QMessageBox.Yes:
             return
-        data.delete_person(person["id"])
+        try:
+            data.delete_person(person["id"])
+        except Exception as exc:  # noqa: BLE001
+            self._report_error("Delete person", exc)
+            return
         if self.active_person_id == person["id"]:
             self.active_person_id = None
         self.refresh_all()

--- a/main.py
+++ b/main.py
@@ -1,17 +1,56 @@
 """myPhotos — face cataloging desktop app (PySide6 + OpenCV + SQLite)."""
 
+import logging
+import os
 import sys
+from logging.handlers import RotatingFileHandler
 
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QMessageBox
 
 from database import init_db
 from gui.theme import STYLESHEET, app_icon, make_palette
 from gui.window import MainWindow
+from paths import data_dir, is_frozen
 
 __version__ = "1.0.1"
 
+log = logging.getLogger(__name__)
+
+
+def setup_logging():
+    """Console logging always; a rotating log file for frozen builds.
+
+    Packaged executables run windowed (no console), so the file in the data
+    dir is the only way to debug them.
+    """
+    handlers = [logging.StreamHandler()]
+    if is_frozen():
+        handlers.append(
+            RotatingFileHandler(
+                os.path.join(data_dir(), "myphotos.log"),
+                maxBytes=1_000_000,
+                backupCount=1,
+                encoding="utf-8",
+            )
+        )
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        handlers=handlers,
+    )
+
+
+def excepthook(exc_type, exc, tb):
+    """Log unhandled exceptions and tell the user instead of dying silently."""
+    log.critical("Unhandled exception", exc_info=(exc_type, exc, tb))
+    if QApplication.instance() is not None:
+        QMessageBox.critical(None, "myPhotos", f"Unexpected error:\n{exc}")
+
 
 def main():
+    setup_logging()
+    sys.excepthook = excepthook
+    log.info("myPhotos %s starting", __version__)
     init_db()
     app = QApplication(sys.argv)
     app.setOrganizationName("myPhotos")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,67 @@
+"""Error-path tests: data failures surface as dialogs, bad files degrade."""
+
+from PySide6.QtCore import QPointF
+
+import gui.window
+
+
+def _boom(*args, **kwargs):
+    raise RuntimeError("boom")
+
+
+class TestReportedErrors:
+    def test_photo_load_failure_is_reported_not_raised(self, window, monkeypatch):
+        reported = []
+        monkeypatch.setattr(
+            window, "_report_error", lambda title, exc: reported.append(title)
+        )
+        monkeypatch.setattr(gui.window.data, "list_photos", _boom)
+        window.refresh_photos()
+        assert reported == ["Loading photos"]
+
+    def test_person_load_failure_is_reported_not_raised(self, window, monkeypatch):
+        reported = []
+        monkeypatch.setattr(
+            window, "_report_error", lambda title, exc: reported.append(title)
+        )
+        monkeypatch.setattr(gui.window.data, "list_persons", _boom)
+        window.refresh_persons()
+        assert reported == ["Loading people"]
+
+    def test_delete_failure_keeps_window_alive(self, window, monkeypatch, qapp):
+        from PySide6.QtWidgets import QMessageBox
+
+        reported = []
+        monkeypatch.setattr(
+            window, "_report_error", lambda title, exc: reported.append(title)
+        )
+        monkeypatch.setattr(
+            QMessageBox, "question", staticmethod(lambda *a, **k: QMessageBox.Yes)
+        )
+        monkeypatch.setattr(gui.window.data, "delete_person", _boom)
+        person = window.people.persons()[0]
+        window._delete_person(person)
+        assert reported == ["Delete person"]
+        assert len(window.people.persons()) == 2  # nothing was deleted
+
+
+class TestBadFiles:
+    def test_lightbox_shows_message_for_unreadable_file(self, qapp, window):
+        photo = dict(window.gallery._model.photos()[0])
+        photo["path"] = "/nonexistent/gone.jpg"
+        window.lightbox.show_photos([photo], 0)
+        qapp.processEvents()
+        assert window.lightbox._pixmap is None
+        window.lightbox.grab()  # paints the "Could not load image" state
+        window.lightbox.accept()
+
+    def test_unreadable_thumbnail_source_does_not_crash_loader(self, qapp, window):
+        from tests.conftest import wait_idle
+
+        photo = dict(window.gallery._model.photos()[0])
+        photo["id"] = 987654
+        photo["path"] = "/nonexistent/gone.jpg"
+        assert window.loader.thumbnail(photo, "34") is None
+        wait_idle(qapp, window)
+        assert (987654, "34") not in window.loader._thumbs  # nothing cached
+        assert window.loader.is_idle()  # the failed job did not get stuck


### PR DESCRIPTION
Addresses the two valid points from an external review:

- `logging` everywhere instead of `print`; frozen builds write a rotating `~/.myphoto/myphotos.log` (windowed executables have no console), plus a global excepthook that logs and shows unexpected errors.
- Data-layer failures (corrupted DB etc.) surface as an error dialog instead of crashing; unreadable images are logged, the lightbox shows a "Could not load image" message, loader worker failures can no longer kill the thread pool.

5 new tests (45 total).