### PR TITLE
Add type annotations and greedy-pass clustering tests

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -2,7 +2,9 @@
 
 import logging
 import os
+import sqlite3
 import threading
+from collections.abc import Set
 
 import cv2
 import numpy as np
@@ -33,7 +35,7 @@ MIN_FACE_SIZE = 24
 MAX_EMBEDDINGS_PER_PERSON = 32
 
 
-def scan_image_files(folder):
+def scan_image_files(folder: str) -> list[str]:
     """Return sorted list of image file paths under folder, recursively."""
     files = []
     for root, _dirs, names in os.walk(folder):
@@ -44,12 +46,12 @@ def scan_image_files(folder):
     return files
 
 
-def _normalize(vec):
+def _normalize(vec: np.ndarray) -> np.ndarray:
     norm = np.linalg.norm(vec)
     return vec / norm if norm > 0 else vec
 
 
-def _average_linkage(embeddings, threshold):
+def _average_linkage(embeddings: np.ndarray, threshold: float) -> list[list[int]]:
     """Agglomerative average-linkage clustering on cosine similarities.
 
     Uses Lance-Williams updates on a full similarity matrix: O(n^2) memory,
@@ -89,10 +91,10 @@ def _average_linkage(embeddings, threshold):
 class Analyzer:
     """Runs analysis in a background thread and exposes progress state."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._thread = None
-        self.progress = {
+        self._thread: threading.Thread | None = None
+        self.progress: dict[str, object] = {
             "status": "idle",  # idle | running | done | error
             "total": 0,
             "done": 0,
@@ -100,18 +102,18 @@ class Analyzer:
             "error": "",
         }
 
-    def _set(self, **kwargs):
+    def _set(self, **kwargs: object) -> None:
         with self._lock:
             self.progress.update(kwargs)
 
-    def get_progress(self):
+    def get_progress(self) -> dict[str, object]:
         with self._lock:
             return dict(self.progress)
 
-    def is_running(self):
+    def is_running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
 
-    def start(self, folder):
+    def start(self, folder: str) -> bool:
         if self.is_running():
             return False
         self._set(status="running", total=0, done=0, current="", error="")
@@ -121,7 +123,7 @@ class Analyzer:
 
     # ---------------------------------------------------------------- core
 
-    def _run(self, folder):
+    def _run(self, folder: str) -> None:
         try:
             detector = cv2.FaceDetectorYN.create(
                 DETECTOR_MODEL, "", (320, 320), DETECTION_SCORE_THRESHOLD
@@ -153,9 +155,9 @@ class Analyzer:
             log.exception("analysis of %s failed", folder)
             self._set(status="error", error=str(exc))
 
-    def _load_persons(self, db):
+    def _load_persons(self, db: sqlite3.Connection) -> dict[int, list[np.ndarray]]:
         """Load stored embeddings grouped by person for incremental clustering."""
-        persons = {}
+        persons: dict[int, list[np.ndarray]] = {}
         rows = db.execute(
             "SELECT person_id, embedding FROM faces WHERE person_id IS NOT NULL"
         ).fetchall()
@@ -166,7 +168,14 @@ class Analyzer:
             del embeddings[MAX_EMBEDDINGS_PER_PERSON:]
         return persons
 
-    def _process_photo(self, db, detector, recognizer, persons, path):
+    def _process_photo(
+        self,
+        db: sqlite3.Connection,
+        detector: cv2.FaceDetectorYN,
+        recognizer: cv2.FaceRecognizerSF,
+        persons: dict[int, list[np.ndarray]],
+        path: str,
+    ) -> None:
         mtime = os.path.getmtime(path)
         existing = db.execute("SELECT id, mtime FROM photos WHERE path = ?", (path,)).fetchone()
         if existing is not None:
@@ -220,7 +229,12 @@ class Analyzer:
                 )
         db.commit()
 
-    def _assign_person(self, db, persons, embedding):
+    def _assign_person(
+        self,
+        db: sqlite3.Connection,
+        persons: dict[int, list[np.ndarray]],
+        embedding: np.ndarray,
+    ) -> int:
         """Greedy mean-linkage match against known persons (live preview only).
 
         The final grouping is decided by _recluster() at the end of the run.
@@ -241,7 +255,7 @@ class Analyzer:
         return person_id
 
     @staticmethod
-    def _create_person(db):
+    def _create_person(db: sqlite3.Connection) -> int:
         cur = db.execute("INSERT INTO persons (name) VALUES ('')")
         person_id = cur.lastrowid
         db.execute("UPDATE persons SET name = ? WHERE id = ?", (f"Persona {person_id}", person_id))
@@ -249,7 +263,9 @@ class Analyzer:
 
     # ----------------------------------------------------------- clustering
 
-    def _recluster(self, db, confirmed_ids=frozenset()):
+    def _recluster(
+        self, db: sqlite3.Connection, confirmed_ids: Set[int] = frozenset()
+    ) -> None:
         """Re-cluster all faces with average-linkage and remap to existing persons.
 
         Mapping clusters back to persons uses two passes:
@@ -314,7 +330,7 @@ class Analyzer:
         db.commit()
 
     @staticmethod
-    def _read_with_pillow(path):
+    def _read_with_pillow(path: str) -> np.ndarray | None:
         """Fallback reader for formats cv2.imread cannot open."""
         try:
             from PIL import Image

--- a/database.py
+++ b/database.py
@@ -40,13 +40,13 @@ CREATE INDEX IF NOT EXISTS idx_faces_person ON faces(person_id);
 """
 
 
-def get_db():
+def get_db() -> sqlite3.Connection:
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys = ON")
     return conn
 
 
-def init_db():
+def init_db() -> None:
     with get_db() as conn:
         conn.executescript(SCHEMA)

--- a/gui/data.py
+++ b/gui/data.py
@@ -8,7 +8,9 @@ THUMB_MAX = {"34": (450, 600), "43": (600, 450)}
 PORTRAIT_SIZE = 128
 
 
-def compute_crop(width, height, faces, aspect):
+def compute_crop(
+    width: int, height: int, faces: list[dict], aspect: float
+) -> dict[str, int]:
     """Fixed-aspect crop window centered on the faces' bounding box (or the middle).
 
     Returned in original-image coordinates; the same window is used to build
@@ -33,7 +35,7 @@ def compute_crop(width, height, faces, aspect):
     return {"x": x, "y": y, "w": crop_w, "h": crop_h}
 
 
-def list_photos(person_id=None, aspect_key="34"):
+def list_photos(person_id: int | None = None, aspect_key: str = "34") -> list[dict]:
     db = get_db()
     if person_id is None:
         rows = db.execute("SELECT * FROM photos ORDER BY filename").fetchall()
@@ -79,7 +81,7 @@ def list_photos(person_id=None, aspect_key="34"):
     ]
 
 
-def list_persons():
+def list_persons() -> list[dict]:
     db = get_db()
     rows = db.execute(
         "SELECT pe.id, pe.name,"
@@ -94,14 +96,14 @@ def list_persons():
     return [dict(r) for r in rows]
 
 
-def rename_person(person_id, name):
+def rename_person(person_id: int, name: str) -> None:
     db = get_db()
     db.execute("UPDATE persons SET name = ? WHERE id = ?", (name, person_id))
     db.commit()
     db.close()
 
 
-def delete_person(person_id):
+def delete_person(person_id: int) -> None:
     """Delete a person together with its face boxes (e.g. false detections)."""
     db = get_db()
     db.execute("DELETE FROM faces WHERE person_id = ?", (person_id,))
@@ -110,7 +112,7 @@ def delete_person(person_id):
     db.close()
 
 
-def merge_person(source_id, target_id):
+def merge_person(source_id: int, target_id: int) -> None:
     """Move all faces of source_id into target_id and delete source_id."""
     db = get_db()
     db.execute("UPDATE faces SET person_id = ? WHERE person_id = ?", (target_id, source_id))
@@ -119,7 +121,7 @@ def merge_person(source_id, target_id):
     db.close()
 
 
-def face_portrait_source(face_id):
+def face_portrait_source(face_id: int) -> dict | None:
     """Photo path and face rect for a person's avatar, or None if missing."""
     db = get_db()
     row = db.execute(

--- a/paths.py
+++ b/paths.py
@@ -4,18 +4,18 @@ import os
 import sys
 
 
-def is_frozen():
-    return getattr(sys, "frozen", False)
+def is_frozen() -> bool:
+    return bool(getattr(sys, "frozen", False))
 
 
-def resource_dir():
+def resource_dir() -> str:
     """Directory with bundled read-only resources (static/, models/)."""
     if is_frozen():
         return sys._MEIPASS  # noqa: SLF001 - PyInstaller runtime attribute
     return os.path.dirname(os.path.abspath(__file__))
 
 
-def data_dir():
+def data_dir() -> str:
     """Writable directory for the SQLite database."""
     if is_frozen():
         path = os.path.join(os.path.expanduser("~"), ".myphoto")
@@ -24,7 +24,7 @@ def data_dir():
     return os.path.dirname(os.path.abspath(__file__))
 
 
-def default_photos_dir():
+def default_photos_dir() -> str:
     local = os.path.join(os.path.dirname(os.path.abspath(__file__)), "photos")
     if not is_frozen() and os.path.isdir(local):
         return local

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -3,7 +3,13 @@
 import numpy as np
 
 import analyzer
-from analyzer import Analyzer, _average_linkage, _normalize, scan_image_files
+from analyzer import (
+    GREEDY_THRESHOLD,
+    Analyzer,
+    _average_linkage,
+    _normalize,
+    scan_image_files,
+)
 
 
 def _unit(dim, axis, noise_seed=None):
@@ -47,6 +53,64 @@ class TestAverageLinkage:
         embeddings = np.stack([_unit(4, i) for i in range(4)])
         clusters = _average_linkage(embeddings, threshold=0.3)
         assert len(clusters) == 4
+
+
+def _with_similarity(cos):
+    """Unit vector whose dot product with the axis-0 unit vector equals cos."""
+    vec = np.zeros(8, dtype=np.float32)
+    vec[0] = cos
+    vec[1] = np.sqrt(1.0 - cos * cos)
+    return vec
+
+
+class TestAssignPerson:
+    def test_close_embedding_joins_existing_person(self, db):
+        conn = db.get_db()
+        a = Analyzer()
+        persons = {}
+        first = a._assign_person(conn, persons, _unit(8, 0))
+        second = a._assign_person(conn, persons, _with_similarity(0.9))
+        assert second == first
+        assert len(persons[first]) == 2
+        conn.close()
+
+    def test_distant_embedding_creates_new_person(self, db):
+        conn = db.get_db()
+        a = Analyzer()
+        persons = {}
+        first = a._assign_person(conn, persons, _unit(8, 0))
+        second = a._assign_person(conn, persons, _unit(8, 1))
+        assert second != first
+        assert set(persons) == {first, second}
+        names = {r["name"] for r in conn.execute("SELECT name FROM persons")}
+        assert names == {f"Persona {first}", f"Persona {second}"}
+        conn.close()
+
+    def test_similarity_threshold_boundary(self, db):
+        conn = db.get_db()
+        a = Analyzer()
+        persons = {}
+        first = a._assign_person(conn, persons, _unit(8, 0))
+        joined = a._assign_person(
+            conn, persons, _with_similarity(GREEDY_THRESHOLD + 0.02)
+        )
+        assert joined == first
+        split = a._assign_person(
+            conn, {first: [_unit(8, 0)]}, _with_similarity(GREEDY_THRESHOLD - 0.02)
+        )
+        assert split != first
+        conn.close()
+
+    def test_embeddings_per_person_are_capped(self, db, monkeypatch):
+        monkeypatch.setattr(analyzer, "MAX_EMBEDDINGS_PER_PERSON", 3)
+        conn = db.get_db()
+        a = Analyzer()
+        persons = {}
+        first = a._assign_person(conn, persons, _unit(8, 0))
+        for seed in range(1, 6):
+            assert a._assign_person(conn, persons, _unit(8, 0, seed)) == first
+        assert len(persons[first]) == 3  # capped, membership unchanged
+        conn.close()
 
 
 def _seed_faces(db, groups):


### PR DESCRIPTION
Follow-up on the updated external review:

- Type annotations on all public/inner signatures in `analyzer.py`, `gui/data.py`, `database.py`, `paths.py` (no behavior change).
- Direct tests for the greedy `_assign_person` pass: join vs new person, exact `GREEDY_THRESHOLD` boundary, `MAX_EMBEDDINGS_PER_PERSON` cap. 49 tests total.